### PR TITLE
Add #code to error classes defined by register_error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_error_registry (0.1.4)
+    nxt_error_registry (0.1.5)
       activesupport (< 6.1)
       rails (< 6.1)
 
@@ -150,7 +150,7 @@ GEM
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.3.0)
+    zeitwerk (2.3.1)
 
 PLATFORMS
   ruby

--- a/lib/nxt_error_registry.rb
+++ b/lib/nxt_error_registry.rb
@@ -20,6 +20,7 @@ module NxtErrorRegistry
       inherited_options = type.try(:options) || {}
       inherited_options.merge(opts)
     end
+    error_class.delegate :code, to: :class
 
     const_set(name, error_class)
     entry = { code: code, error_class: error_class, type: type, name: name, namespace: self.to_s, opts: opts }

--- a/lib/nxt_error_registry/version.rb
+++ b/lib/nxt_error_registry/version.rb
@@ -1,3 +1,3 @@
 module NxtErrorRegistry
-  VERSION = "0.1.4".freeze
+  VERSION = "0.1.5".freeze
 end

--- a/spec/nxt_error_registry_spec.rb
+++ b/spec/nxt_error_registry_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe NxtErrorRegistry do
         level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.100'
         expect(level_one::LevelOneError.code).to eq('100.100')
       end
+
+      it 'defines the instance method too' do
+        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.100'
+        instance = level_one::LevelOneError.new('Error!')
+        expect(instance.code).to eq('100.100')
+      end
     end
 
     context 'options' do


### PR DESCRIPTION
Added an instance method `#code` that is delegated to the class method `.code`.

This will indirectly fix the errors like https://sentry.io/organizations/nxt-insurance/issues/1728805193/?project=204070 once the new version of this gem is used in the service.