### PR TITLE
Delegate #code after const_set

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_error_registry (0.1.5)
+    nxt_error_registry (0.1.6)
       activesupport (< 6.1)
       rails (< 6.1)
 
@@ -86,7 +86,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     nio4r (2.5.2)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     pry (0.13.1)
       coderay (~> 1.1)

--- a/lib/nxt_error_registry.rb
+++ b/lib/nxt_error_registry.rb
@@ -20,9 +20,12 @@ module NxtErrorRegistry
       inherited_options = type.try(:options) || {}
       inherited_options.merge(opts)
     end
-    error_class.delegate :code, to: :class
 
     const_set(name, error_class)
+    # Calling `delegate` before `const_set` would rip off the modules from the error class.
+    # e.g. `Module1::Module2::MyError` would become `MyError`.
+    error_class.delegate :code, to: :class
+
     entry = { code: code, error_class: error_class, type: type, name: name, namespace: self.to_s, opts: opts }
     error_registry[name.to_s] = entry
 

--- a/lib/nxt_error_registry/version.rb
+++ b/lib/nxt_error_registry/version.rb
@@ -1,3 +1,3 @@
 module NxtErrorRegistry
-  VERSION = "0.1.5".freeze
+  VERSION = "0.1.6".freeze
 end


### PR DESCRIPTION
Call `delegate` AFTER `const_set` to prevent the class from being defined without namespaces.

Kudos to @lutfidemirci for the findings!