### PR TITLE
Random alphanumeric error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# v0.2.0 2020-08-25
+
+### Added
+ 
+- Use uuids as codes instead of numeric codes in sequence 
+
+[Compare v0.1.6...v0.2.0](https://github.com/nxt-insurance/nxt_error_registry/compare/v0.1.6...v0.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_error_registry (0.1.6)
+    nxt_error_registry (0.2.0)
       activesupport (< 6.1)
       rails (< 6.1)
 
@@ -65,13 +65,13 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     builder (3.2.4)
     coderay (1.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     crass (1.0.6)
     diff-lcs (1.3)
     erubi (1.9.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    i18n (1.8.3)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     loofah (2.6.0)
       crass (~> 1.0.2)
@@ -147,10 +147,10 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    websocket-driver (0.7.2)
+    websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.3.1)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Or install it yourself as:
 ```ruby
 class LevelOne
   extend NxtErrorRegistry
-  register_error :LevelOneError, type: StandardError, code: 'r0b.1b0'
+  register_error :LevelOneError, type: StandardError, code: '84b67c94-efb4-48e8-a5e9-ed1fa1beb988'
   # This will set the LevelOne::LevelOneError constant that you can raise anywhere
-  register_error :LevelTwoError, type: LevelOneError, code: 'ah6.1h1', capture: true, reraise: false
+  register_error :LevelTwoError, type: LevelOneError, code: 'a7fc9a8c-9f83-4a2d-8808-75dbef8e376f', capture: true, reraise: false
   # You can also pass in additional options when registering your errors. These will be available on you error class 
   
   def raise_level_one_error
@@ -48,7 +48,7 @@ All arguments are optional and will be set to a placeholder if not provided
 
 ```ruby
 rails g register_error --name NewErrorName --type SomeKindOfError 
-# => register_error :NewErrorName, type: SomeKindOfError, code: '45h.74g'
+# => register_error :NewErrorName, type: SomeKindOfError, code: 'fa7afa83-6c68-4186-ada4-a573b6a72bd9'
 ``` 
 
 ### Or use the rake task instead. 
@@ -57,7 +57,7 @@ All arguments are optional and will be set to a placeholder if not provided
 
 ```ruby
 rake nxt_error_registry:generate_code\[ErrorName,ParentType\] 
-# => register_error :ErrorName, type: ParentType, code: 'r5h.h00'
+# => register_error :ErrorName, type: ParentType, code: '5c8152cd-b8b9-4fb0-a5fe-5c11d200affc'
 ```
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Or install it yourself as:
 ```ruby
 class LevelOne
   extend NxtErrorRegistry
-  register_error :LevelOneError, type: StandardError, code: '100.100'
+  register_error :LevelOneError, type: StandardError, code: 'r0b.1b0'
   # This will set the LevelOne::LevelOneError constant that you can raise anywhere
-  register_error :LevelTwoError, type: LevelOneError, code: '100.101', capture: true, reraise: false
+  register_error :LevelTwoError, type: LevelOneError, code: 'ah6.1h1', capture: true, reraise: false
   # You can also pass in additional options when registering your errors. These will be available on you error class 
   
   def raise_level_one_error
@@ -48,7 +48,7 @@ All arguments are optional and will be set to a placeholder if not provided
 
 ```ruby
 rails g register_error --name NewErrorName --type SomeKindOfError 
-# => register_error :NewErrorName, type: SomeKindOfError, code: '100.000'
+# => register_error :NewErrorName, type: SomeKindOfError, code: '45h.74g'
 ``` 
 
 ### Or use the rake task instead. 
@@ -57,7 +57,7 @@ All arguments are optional and will be set to a placeholder if not provided
 
 ```ruby
 rake nxt_error_registry:generate_code\[ErrorName,ParentType\] 
-# => register_error :ErrorName, type: ParentType, code: '100.000'
+# => register_error :ErrorName, type: ParentType, code: 'r5h.h00'
 ```
 ## Development
 

--- a/lib/nxt_error_registry/codes_harness.rb
+++ b/lib/nxt_error_registry/codes_harness.rb
@@ -2,39 +2,25 @@ require 'singleton'
 
 module NxtErrorRegistry
   class CodesHarness
+    CodeAlreadyRegistered = Class.new(StandardError)
     include Singleton
 
     def generate_code
-      puts "WARNING: Codes are not in sequence: #{codes_not_in_sequence}" if codes_not_in_sequence.any?
-
-      last_id = codes_as_ids.last
-      return '100.000' unless last_id
-
-      next_id = last_id + 1
-      id_to_code(next_id)
+      generate_next_code
+    rescue CodeAlreadyRegistered
+      retry
     end
 
-    def codes_not_in_sequence
-      previous_id = nil
+    def generate_next_code
+      chars = SecureRandom.hex(4).chars
+      new_code = "#{chars[0..2].join}.#{chars[3..-1].join}"
+      return new_code unless registered_codes.include?(new_code)
 
-      codes_as_ids.inject([]) do |acc, id|
-        if !previous_id || previous_id + 1 == id
-          previous_id = id
-          acc
-        else
-          acc << [previous_id, id]
-          previous_id = id
-          acc
-        end
-      end
+      raise CodeAlreadyRegistered, "#{new_code} already registered"
     end
 
-    def codes_as_ids
-      registry.codes.map { |code| Integer(code.delete('.')) }.sort
-    end
-
-    def id_to_code(code)
-      "#{code.to_s[0..2]}.#{code.to_s[3..-1]}"
+    def registered_codes
+      registry.codes
     end
 
     def registry

--- a/lib/nxt_error_registry/codes_harness.rb
+++ b/lib/nxt_error_registry/codes_harness.rb
@@ -12,8 +12,7 @@ module NxtErrorRegistry
     end
 
     def generate_next_code
-      chars = SecureRandom.hex(4).chars
-      new_code = "#{chars[0..2].join}.#{chars[3..-1].join}"
+      new_code = SecureRandom.uuid
       return new_code unless registered_codes.include?(new_code)
 
       raise CodeAlreadyRegistered, "#{new_code} already registered"

--- a/lib/nxt_error_registry/default_code_validator.rb
+++ b/lib/nxt_error_registry/default_code_validator.rb
@@ -3,7 +3,7 @@ module NxtErrorRegistry
     CodeAlreadyTakenError = Class.new(StandardError)
     InvalidCodeFormatError = Class.new(StandardError)
 
-    FORMAT = /\A[a-zA-Z0-9]{3}\.[a-zA-Z0-9]{3}\z/
+    FORMAT = /\A[a-zA-Z0-9-]{36}\z/
 
     def initialize(name, type, code, context)
       @name = name

--- a/lib/nxt_error_registry/default_code_validator.rb
+++ b/lib/nxt_error_registry/default_code_validator.rb
@@ -3,7 +3,7 @@ module NxtErrorRegistry
     CodeAlreadyTakenError = Class.new(StandardError)
     InvalidCodeFormatError = Class.new(StandardError)
 
-    FORMAT = /\A\d{3}\.\d{3}\z/
+    FORMAT = /\A[a-zA-Z0-9]{3}\.[a-zA-Z0-9]{3}\z/
 
     def initialize(name, type, code, context)
       @name = name
@@ -25,6 +25,7 @@ module NxtErrorRegistry
 
     def validate_code_format
       return if code =~ FORMAT
+
       raise InvalidCodeFormatError, "Code #{code} for name #{name} violates format #{FORMAT} in context: #{context}"
     end
 

--- a/lib/nxt_error_registry/default_code_validator.rb
+++ b/lib/nxt_error_registry/default_code_validator.rb
@@ -29,7 +29,7 @@ module NxtErrorRegistry
     end
 
     def validate_code_uniqueness
-      duplicates = registry.duplicate_codes
+      duplicates = registry.duplicated_codes
       return if duplicates.empty?
 
       raise CodeAlreadyTakenError, "The following codes are duplicated: #{duplicates.keys.join(',')}"

--- a/lib/nxt_error_registry/registry.rb
+++ b/lib/nxt_error_registry/registry.rb
@@ -32,7 +32,7 @@ module NxtErrorRegistry
       end
     end
 
-    def duplicate_codes
+    def duplicated_codes
       entries_by_codes.select { |_, v| v.size > 1 }
     end
   end

--- a/lib/nxt_error_registry/version.rb
+++ b/lib/nxt_error_registry/version.rb
@@ -1,3 +1,3 @@
 module NxtErrorRegistry
-  VERSION = "0.1.6".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/spec/codes_harness_spec.rb
+++ b/spec/codes_harness_spec.rb
@@ -9,54 +9,13 @@ RSpec.describe NxtErrorRegistry::CodesHarness do
 
   BadError = Class.new(StandardError)
 
-  describe '#codes_not_in_sequence' do
-    let(:registry) { NxtErrorRegistry::Registry.send(:new) }
-
-    context 'when the codes are in sequence' do
-      before do
-        allow(NxtErrorRegistry::Registry).to receive(:instance).and_return(registry)
-
-        test_class.register_error :LevelOneError, type: BadError, code: '100.000'
-        test_class.register_error :LevelOneError, type: BadError, code: '100.003'
-        test_class.register_error :LevelOneError, type: BadError, code: '100.001'
-        test_class.register_error :LevelOneError, type: BadError, code: '100.002'
-      end
-
-      it 'returns an empty array' do
-        expect(subject.codes_not_in_sequence).to be_empty
-      end
-    end
-
-    context 'when codes are not in sequence' do
-      before do
-        allow(NxtErrorRegistry::Registry).to receive(:instance).and_return(registry)
-
-        test_class.register_error :LevelOneError, type: BadError, code: '100.000'
-        test_class.register_error :LevelOneError, type: BadError, code: '100.003'
-        test_class.register_error :LevelOneError, type: BadError, code: '100.007'
-        test_class.register_error :LevelOneError, type: BadError, code: '100.009'
-        test_class.register_error :LevelOneError, type: BadError, code: '200.009'
-        test_class.register_error :LevelOneError, type: BadError, code: '100.002'
-        test_class.register_error :LevelOneError, type: BadError, code: '100.005'
-      end
-
-      it 'returns the tuples with a distance greater one' do
-        expect(
-          subject.codes_not_in_sequence
-        ).to eq([[100000, 100002], [100003, 100005], [100005, 100007], [100007, 100009], [100009, 200009]])
-      end
-    end
-  end
-
   describe '#generate_code' do
+    before do
+      expect(SecureRandom).to receive(:hex).and_return('123456')
+    end
+
     it 'generates the next code' do
-      expect(subject.generate_code).to eq('100.000')
-      test_class.register_error :LevelOneError, type: BadError, code: '100.001'
-      test_class.register_error :LevelOneError, type: BadError, code: '100.002'
-      expect(subject.generate_code).to eq('100.003')
-      expect(subject.generate_code).to eq('100.003')
-      test_class.register_error :LevelOneError, type: BadError, code: '100.003'
-      expect(subject.generate_code).to eq('100.004')
+      expect(subject.generate_code).to eq('123.456')
     end
   end
 end

--- a/spec/codes_harness_spec.rb
+++ b/spec/codes_harness_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe NxtErrorRegistry::CodesHarness do
 
   describe '#generate_code' do
     before do
-      expect(SecureRandom).to receive(:hex).and_return('123456')
+      expect(SecureRandom).to receive(:uuid).and_return('5c8152cd-b8b9-4fb0-a5fe-5c11d200affc')
     end
 
     it 'generates the next code' do
-      expect(subject.generate_code).to eq('123.456')
+      expect(subject.generate_code).to eq('5c8152cd-b8b9-4fb0-a5fe-5c11d200affc')
     end
   end
 end

--- a/spec/nxt_error_registry_spec.rb
+++ b/spec/nxt_error_registry_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe NxtErrorRegistry do
       end
 
       it 'registers a new error class with the :code method' do
-        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.100'
-        expect(level_one::LevelOneError.code).to eq('100.100')
+        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.abc'
+        expect(level_one::LevelOneError.code).to eq('100.abc')
       end
 
       it 'defines the instance method too' do
-        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.100'
+        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.abc'
         instance = level_one::LevelOneError.new('Error!')
-        expect(instance.code).to eq('100.100')
+        expect(instance.code).to eq('100.abc')
       end
     end
 
@@ -100,13 +100,13 @@ RSpec.describe NxtErrorRegistry do
 
       before do
         allow(NxtErrorRegistry::Registry).to receive(:instance).and_return(registry)
-        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.100'
+        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.abc'
       end
 
       it 'raises an error' do
         expect {
-          level_two.register_error :LevelTwoError, type: TestErrors::BadError, code: '100.100'
-        }.to raise_error(NxtErrorRegistry::DefaultCodeValidator::CodeAlreadyTakenError, "The following codes are duplicated: 100.100")
+          level_two.register_error :LevelTwoError, type: TestErrors::BadError, code: '100.abc'
+        }.to raise_error(NxtErrorRegistry::DefaultCodeValidator::CodeAlreadyTakenError, "The following codes are duplicated: 100.abc")
       end
     end
 

--- a/spec/nxt_error_registry_spec.rb
+++ b/spec/nxt_error_registry_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe NxtErrorRegistry do
       end
 
       it 'registers a new error class with the :code method' do
-        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.abc'
-        expect(level_one::LevelOneError.code).to eq('100.abc')
+        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '04ac98bd-a89e-4e4a-8448-7197dbd76623'
+        expect(level_one::LevelOneError.code).to eq('04ac98bd-a89e-4e4a-8448-7197dbd76623')
       end
 
       it 'defines the instance method too' do
-        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.abc'
+        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '04ac98bd-a89e-4e4a-8448-7197dbd76623'
         instance = level_one::LevelOneError.new('Error!')
-        expect(instance.code).to eq('100.abc')
+        expect(instance.code).to eq('04ac98bd-a89e-4e4a-8448-7197dbd76623')
       end
     end
 
@@ -43,7 +43,7 @@ RSpec.describe NxtErrorRegistry do
 
       before do
         allow(NxtErrorRegistry::Registry).to receive(:instance).and_return(registry)
-        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.100', capture: false
+        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '04ac98bd-a89e-4e4a-8448-7197dbd76623', capture: false
       end
 
       it 'sets the options on the class' do
@@ -51,7 +51,7 @@ RSpec.describe NxtErrorRegistry do
       end
 
       it 'can be extended by the subclass' do
-        level_one.register_error :LevelTwoError, type: level_one::LevelOneError, code: '100.101', capture: true, reraise: true
+        level_one.register_error :LevelTwoError, type: level_one::LevelOneError, code: '14fc94dd-a159-4e58-bfc2-b35b59e8bb15', capture: true, reraise: true
         expect(level_one::LevelTwoError.options).to eq(capture: true, reraise: true)
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe NxtErrorRegistry do
 
       it 'creates a new error class' do
         expect {
-          level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.100'
+          level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '14fc94dd-a159-4e58-bfc2-b35b59e8bb15'
         }.to change {
           level_one.const_defined?('LevelOneError')
         }.from(false).to(true)
@@ -77,12 +77,12 @@ RSpec.describe NxtErrorRegistry do
       end
 
       it 'registers the error class in the registry' do
-        level_two.register_error :LevelTwoError, type: TestErrors::BadError, code: '100.101'
+        level_two.register_error :LevelTwoError, type: TestErrors::BadError, code: 'bddf958e-0e74-4729-b63f-1367a2103e53'
 
         expect(
           NxtErrorRegistry::Registry.instance[level_two.to_s]['LevelTwoError']
         ).to eq(
-          :code => "100.101",
+          :code => "bddf958e-0e74-4729-b63f-1367a2103e53",
           :error_class => level_two::LevelTwoError,
           :name => :LevelTwoError,
           :namespace => level_two.to_s,
@@ -100,13 +100,13 @@ RSpec.describe NxtErrorRegistry do
 
       before do
         allow(NxtErrorRegistry::Registry).to receive(:instance).and_return(registry)
-        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.abc'
+        level_one.register_error :LevelOneError, type: TestErrors::BadError, code: 'bddf958e-0e74-4729-b63f-1367a2103e53'
       end
 
       it 'raises an error' do
         expect {
-          level_two.register_error :LevelTwoError, type: TestErrors::BadError, code: '100.abc'
-        }.to raise_error(NxtErrorRegistry::DefaultCodeValidator::CodeAlreadyTakenError, "The following codes are duplicated: 100.abc")
+          level_two.register_error :LevelTwoError, type: TestErrors::BadError, code: 'bddf958e-0e74-4729-b63f-1367a2103e53'
+        }.to raise_error(NxtErrorRegistry::DefaultCodeValidator::CodeAlreadyTakenError, 'The following codes are duplicated: bddf958e-0e74-4729-b63f-1367a2103e53')
       end
     end
 
@@ -118,12 +118,12 @@ RSpec.describe NxtErrorRegistry do
 
         before do
           allow(NxtErrorRegistry::Registry).to receive(:instance).and_return(registry)
-          level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.101'
+          level_one.register_error :LevelOneError, type: TestErrors::BadError, code: 'bddf958e-0e74-4729-b63f-1367a2103e53'
         end
 
         it 'raises an error' do
           expect {
-            level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.102'
+            level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '15e37258-b0f9-4dc1-b154-8c6bd9004ead'
           }.to raise_error(NxtErrorRegistry::RegistrationError, "LevelOneError was already registered in #{level_one}")
         end
       end
@@ -136,12 +136,12 @@ RSpec.describe NxtErrorRegistry do
 
         before do
           allow(NxtErrorRegistry::Registry).to receive(:instance).and_return(registry)
-          level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '100.103'
+          level_one.register_error :LevelOneError, type: TestErrors::BadError, code: '15e37258-b0f9-4dc1-b154-8c6bd9004ead'
         end
 
         it 'does not raise en error' do
           expect {
-            level_two.register_error :LevelOneError, type: TestErrors::BadError, code: '100.104'
+            level_two.register_error :LevelOneError, type: TestErrors::BadError, code: '3317bfff-3fed-45aa-8626-371eef1b33ab'
           }.to_not raise_error
         end
       end

--- a/spec/registry_spec.rb
+++ b/spec/registry_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe NxtErrorRegistry::Registry do
     end
 
     it 'returns the entries that have the same code' do
-      expect(subject.duplicate_codes).to eq("100.101"=>[{:code=>"100.101"}, {:code=>"100.101"}])
+      expect(subject.duplicated_codes).to eq("100.101"=>[{:code=>"100.101"}, {:code=>"100.101"}])
     end
   end
 end


### PR DESCRIPTION
This changes error registry to use random alphanumeric codes instead of sequential `100.000` code like before. @yamov @barbogast hope this is not a problem for the frontend. Of course we will not change any existing codes but are likely to introduce alphanumeric codes in the style of `r0b.3ck` soon.

@nxt-insurance/backend The reason for having codes in sequence originally was so that a code that previously existed and does not exist anymore can not be reassigned a second time. I guess this is very unlikely to happen here, but there is a possibility. Might be ok to live with this, but I guess I don't like it.