### PR TITLE
Allow legacy codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.2.1 2020-08-28
+
+### Fixed
+ 
+- Allow legacy codes of format /\A\d{3}\.\d{3}\z/ 
+
+[Compare v0.2.0...v0.2.1](https://github.com/nxt-insurance/nxt_error_registry/compare/v0.2.0...v0.2.1)
+
 # v0.2.0 2020-08-25
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_error_registry (0.2.0)
+    nxt_error_registry (0.2.1)
       activesupport (< 6.1)
       rails (< 6.1)
 
@@ -73,7 +73,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    loofah (2.6.0)
+    loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)

--- a/lib/nxt_error_registry/default_code_validator.rb
+++ b/lib/nxt_error_registry/default_code_validator.rb
@@ -3,7 +3,8 @@ module NxtErrorRegistry
     CodeAlreadyTakenError = Class.new(StandardError)
     InvalidCodeFormatError = Class.new(StandardError)
 
-    FORMAT = /\A[a-zA-Z0-9-]{36}|\d{3}\.\d{3}\z/
+    LEGACY_FORMAT = /\A\d{3}\.\d{3}\z/
+    FORMAT = /\A[a-zA-Z0-9-]{36}|#{LEGACY_FORMAT}\z/
 
     def initialize(name, type, code, context)
       @name = name

--- a/lib/nxt_error_registry/default_code_validator.rb
+++ b/lib/nxt_error_registry/default_code_validator.rb
@@ -3,7 +3,7 @@ module NxtErrorRegistry
     CodeAlreadyTakenError = Class.new(StandardError)
     InvalidCodeFormatError = Class.new(StandardError)
 
-    FORMAT = /\A[a-zA-Z0-9-]{36}\z/
+    FORMAT = /\A[a-zA-Z0-9-]{36}|\d{3}\.\d{3}\z/
 
     def initialize(name, type, code, context)
       @name = name

--- a/lib/nxt_error_registry/version.rb
+++ b/lib/nxt_error_registry/version.rb
@@ -1,3 +1,3 @@
 module NxtErrorRegistry
-  VERSION = "0.2.0".freeze
+  VERSION = "0.2.1".freeze
 end

--- a/spec/nxt_error_registry_spec.rb
+++ b/spec/nxt_error_registry_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe NxtErrorRegistry do
         it do
           expect { level_one.register_error :ValidCode, type: TestErrors::BadError, code: '04ac98bd-a89e-4e4a-8448-7197dbd76623' }.to_not raise_error
           expect { level_one.register_error :ValidLegacyCode, type: TestErrors::BadError, code: '123.456' }.to_not raise_error
-          expect { level_one.register_error :NotValid, type: TestErrors::BadError, code: 'other' }.to raise_error(NxtErrorRegistry::DefaultCodeValidator::InvalidCodeFormatError)
+          expect { level_one.register_error :NotValid, type: TestErrors::BadError, code: '123.456.789' }.to raise_error(NxtErrorRegistry::DefaultCodeValidator::InvalidCodeFormatError)
         end
       end
     end

--- a/spec/nxt_error_registry_spec.rb
+++ b/spec/nxt_error_registry_spec.rb
@@ -145,6 +145,17 @@ RSpec.describe NxtErrorRegistry do
           }.to_not raise_error
         end
       end
+
+      context 'code format' do
+        let(:level_one) { test_class }
+        let(:registry) { NxtErrorRegistry::Registry.send(:new) }
+
+        it do
+          expect { level_one.register_error :ValidCode, type: TestErrors::BadError, code: '04ac98bd-a89e-4e4a-8448-7197dbd76623' }.to_not raise_error
+          expect { level_one.register_error :ValidLegacyCode, type: TestErrors::BadError, code: '123.456' }.to_not raise_error
+          expect { level_one.register_error :NotValid, type: TestErrors::BadError, code: 'other' }.to raise_error(NxtErrorRegistry::DefaultCodeValidator::InvalidCodeFormatError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The format should probably be configurable, but for now I simply allow to have legacy code format and uuids. 