### PR TITLE
Loosen Rails and ActiveSupport version constraint to allow 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
+# v0.2.3 2021-01-05
+
+### Updated
+
+- Loosen Rails and ActiveSupport version constraint to allow 6.1
+
 # v0.2.2 2020-12-28
 
 ### Changed
- 
+
 - Updated dependencies
 
 [Compare v0.2.1...v0.2.2](https://github.com/nxt-insurance/nxt_error_registry/compare/v0.2.1...v0.2.2)
@@ -9,15 +15,15 @@
 # v0.2.1 2020-08-28
 
 ### Fixed
- 
-- Allow legacy codes of format /\A\d{3}\.\d{3}\z/ 
+
+- Allow legacy codes of format /\A\d{3}\.\d{3}\z/
 
 [Compare v0.2.0...v0.2.1](https://github.com/nxt-insurance/nxt_error_registry/compare/v0.2.0...v0.2.1)
 
 # v0.2.0 2020-08-25
 
 ### Added
- 
-- Use uuids as codes instead of numeric codes in sequence 
+
+- Use uuids as codes instead of numeric codes in sequence
 
 [Compare v0.1.6...v0.2.0](https://github.com/nxt-insurance/nxt_error_registry/compare/v0.1.6...v0.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    nxt_error_registry (0.2.2)
-      activesupport (<= 6.1.0)
-      rails (<= 6.1.0)
+    nxt_error_registry (0.2.3)
+      activesupport (~> 6.0)
+      rails (~> 6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/nxt_error_registry/version.rb
+++ b/lib/nxt_error_registry/version.rb
@@ -1,3 +1,3 @@
 module NxtErrorRegistry
-  VERSION = "0.2.2".freeze
+  VERSION = "0.2.3".freeze
 end

--- a/nxt_error_registry.gemspec
+++ b/nxt_error_registry.gemspec
@@ -39,6 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4.1"
   spec.add_development_dependency "pry"
-  spec.add_dependency "activesupport", "<= 6.1.0"
-  spec.add_dependency "rails", "<= 6.1.0"
+  spec.add_dependency 'activesupport', '~> 6.0'
+  spec.add_dependency "rails", "~> 6.0"
 end


### PR DESCRIPTION
The current version constraint is blocking the Rails 6.1 upgrade in all services. This will allow any ActiveSupport and Rails version below 7.